### PR TITLE
Proxied console calls with allow list, escaped % calls and froze console

### DIFF
--- a/js/nice-script.js
+++ b/js/nice-script.js
@@ -1,63 +1,66 @@
-var NiceScript = function () {
+var NiceScript = function(){
     function run(code) {
         try {
-            if (checkSyntax(code)) {
+            if(checkSyntax(code)) {
                 var handler = {
-                    get(obj, prop) {
-                        return Reflect.has(obj, prop.toString() + '__$') ? obj[prop.toString() + '__$'] : undefined;
+                    get(obj, prop) {                                                         
+                            return Reflect.has(obj, prop.toString()+'__$') ? obj[prop.toString()+'__$'] : undefined;
                     },
                     set(obj, prop, value) {
-                        Reflect.set(obj, prop + '__$', value);
+                            Reflect.set(obj, prop+'__$', value);
                     },
-                    has(obj, prop) {
-                        return obj && Reflect.has(obj, prop.toString() + '__$');
+                    has(obj,prop) {                        
+                            return obj && Reflect.has(obj, prop.toString()+'__$');
                     }
                 };
                 var catchAllHandler = {
-                    get(obj, prop) {
-                        return Reflect.get(obj, prop);
+                    get(obj, prop){
+                        return Reflect.get(obj,prop);
                     },
-                    set() {
+                    set(){
 
                     },
-                    has() {
-                        return true
-                    }
-                };
-
-                const _consoleHandler = {
-                    get: function (target, prop, receiver) {
-                        const allowProps = ["debug", "error", "info", "log", "warn", 
-                            "dir", "dirxml", "table", "trace", "group", "groupCollapsed", 
-                            "groupEnd", "clear", "count", "countReset", "assert", "profile", 
-                            "profileEnd", "time", "timeLog", "timeEnd", "timeStamp"
-                        ];
-                        if(!allowProps.includes(prop)){
-                            throw new Error(`console[${prop}] is disallowed`);
+                    has(){return true}
+                };   
+                
+                window.console.log = function(original){
+                    return function(){
+                        if(typeof arguments[0] === 'string') {
+                            arguments[0] = arguments[0].replace(/%c/,'');
                         }
-                        if (typeof target[prop] === 'function') {
-                            return function () {
-                                if (arguments.length > 1 && typeof arguments[0] === 'string') {
-                                    arguments[0] = arguments[0].replace(/%/g, '%%')
-                                }
-                                return target[prop](...arguments);
-                            }
-                        } else {
-                            return target[prop];
+                        return original(...arguments);
+                    };
+                }(window.console.info);
+                window.console.info = function(original){
+                    return function(){
+                        if(typeof arguments[0] === 'string') {
+                            arguments[0] = arguments[0].replace(/%c/,'');
                         }
-                    },
-                    set: function () {
-                        throw new Error("Can't override console object");
-                    }
-                };
-
-                const _console = new Proxy(console, _consoleHandler);
-
+                        return original(...arguments);
+                    };
+                }(window.console.info);
+                window.console.warn = function(original){
+                    return function(){
+                        if(typeof arguments[0] === 'string') {
+                            arguments[0] = arguments[0].replace(/%c/,'');
+                        }
+                        return original(...arguments);
+                    };
+                }(window.console.warn);
+                window.console.error = function(original){
+                    return function(){
+                        if(typeof arguments[0] === 'string') {
+                            arguments[0] = arguments[0].replace(/%c/,'');
+                        }
+                        return original(...arguments);
+                    };
+                }(window.console.error);
+            
                 var allowList = {
                     __proto__: null,
-                    console__$: _console,
-                    alert__$: function () {
-                        alert("Sandboxed alert:" + arguments[0]);
+                    console__$:console,
+                    alert__$: function(){ 
+                        alert("Sandboxed alert:"+arguments[0]);
                     },
                     String__$: String,
                     Number__$: Number,
@@ -66,11 +69,11 @@ var NiceScript = function () {
                     Math__$: Math,
                     RegExp__$: RegExp,
                     Object__$: Object,
-                    eval__$: function (code) {
-                        return NiceScript.run("return " + code);
-                    }
+                    eval__$: function(code){
+                        return NiceScript.run("return "+code);
+                    }      
                 };
-                if (!Object.isFrozen(String.prototype)) {
+                if(!Object.isFrozen(String.prototype)) {
                     Function.prototype.constructor = null;
                     Object.freeze(Object);
                     Object.freeze(String);
@@ -82,6 +85,7 @@ var NiceScript = function () {
                     Object.freeze(RegExp);
                     Object.freeze(BigInt);
                     Object.freeze(Promise);
+                    Object.freeze(console);
                     Object.freeze(BigInt.prototype);
                     Object.freeze(Object.prototype);
                     Object.freeze(String.prototype);
@@ -92,45 +96,18 @@ var NiceScript = function () {
                     Object.freeze(Function.prototype);
                     Object.freeze(RegExp.prototype);
                     Object.freeze(Promise.prototype);
-                    Object.defineProperty((async function () {}).constructor.prototype, 'constructor', {
-                        value: null,
-                        configurable: false,
-                        writable: false
-                    });
-                    Object.defineProperty((async function* () {}).constructor.prototype, 'constructor', {
-                        value: null,
-                        configurable: false,
-                        writable: false
-                    });
-                    Object.defineProperty((function* () {}).constructor.prototype, 'constructor', {
-                        value: null,
-                        configurable: false,
-                        writable: false
-                    });
-
-                    Object.freeze((async function () {
-                        return 1
-                    }).__proto__);
-                    Object.freeze((async function* () {
-                        return 1
-                    }).__proto__);
-                    Object.freeze((function* () {
-                        return 1
-                    }).__proto__);
-                    Object.freeze((function* () {
-                        return 1
-                    }).__proto__.prototype);
-                    Object.freeze((async function* () {
-                        return 1
-                    }).__proto__.prototype);
+                    Object.defineProperty((async function(){}).constructor.prototype, 'constructor', {value: null, configurable: false, writable: false});
+                    Object.defineProperty((async function*(){}).constructor.prototype, 'constructor', {value: null, configurable: false, writable: false});
+                    Object.defineProperty((function*(){}).constructor.prototype, 'constructor', {value: null, configurable: false, writable: false}); 
+                    
+                    Object.freeze((async function(){return 1}).__proto__);
+                    Object.freeze((async function *(){return 1}).__proto__);
+                    Object.freeze((function *(){return 1}).__proto__);   
+                    Object.freeze((function *(){return 1}).__proto__.prototype);
+                    Object.freeze((async function *(){return 1}).__proto__.prototype);             
                 }
-                var proxy = new Proxy(allowList, handler);
-                var catchAllProxy = new Proxy({
-                    __proto__: null,
-                    proxy: proxy,
-                    globalThis: new Proxy(allowList, handler),
-                    window: new Proxy(allowList, handler)
-                }, catchAllHandler);
+                var proxy = new Proxy(allowList, handler);  
+                var catchAllProxy = new Proxy({__proto__:null, proxy:proxy, globalThis:new Proxy(allowList, handler), window:new Proxy(allowList, handler)}, catchAllHandler);                     
                 var output = Function('proxy', 'catchAllProxy', `
                     with(catchAllProxy) {     
                         with(proxy) {  
@@ -140,22 +117,19 @@ var NiceScript = function () {
                             })();
                         }
                     }                    
-                `)(proxy, catchAllProxy);
-                return output;
+                `)(proxy, catchAllProxy); 
+                return output;                                       
             }
-        } catch (e) {
+        } catch(e) {
             throw e;
         }
     }
-
     function checkSyntax(code) {
         Function(code);
-        if (/\bimport\s*(?:[(]|\/[*]|\/\/|<!--|-->)/.test(code)) {
+        if(/\bimport\s*(?:[(]|\/[*]|\/\/|<!--|-->)/.test(code)) {
             throw new Error("Dynamic imports are blocked");
         }
         return true;
     }
-    return {
-        run: run
-    };
+    return {run: run};
 }();

--- a/js/nice-script.js
+++ b/js/nice-script.js
@@ -44,7 +44,7 @@ var NiceScript = function(){
 
                 var allowList = {
                     __proto__: null,
-                    console__$:console,
+                    console__$:_console,
                     alert__$: function(){ 
                         alert("Sandboxed alert:"+arguments[0]);
                     },


### PR DESCRIPTION
Only allowed properties on `console` can be called.
`%` character in console calls is escaped so the formatter can't be abused.
Both `console` and `_console` are frozen.


This PR fixes other unmentioned before tricky bypasses, so allow list seems inevitable. 

```js
console.group("%c123", "color:red")
console.context().log("%c321", "color:red")
console.__proto__.test = () => alert();
console.text();
```